### PR TITLE
Add deep link to MetaMask wallet on mobile device

### DIFF
--- a/demo/src/main.ts
+++ b/demo/src/main.ts
@@ -12,6 +12,7 @@ const app = createApp(App)
 app.use(VueDapp, {
   infuraId: isDev ? infuraId : 'ff6a249a74e048f1b413cba715f98d07',
   appName: 'Vue Dapp',
+  appUrl: 'vue-dapp.netlify.app',
 })
 
 app.mount('#app')

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@ const app = createApp(App)
 app.use(VueDapp, {
   infuraId: '...', // optional: for enabling WalletConnect and/or WalletLink
   appName: '...', // optional: for enabling WalletLink
+  appUrl: '...', // optional: for enabling MetaMask deep link for mobile devices
 })
 ...
 ```

--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -27,6 +27,7 @@ export default defineComponent({
     const walletlinkDisabled = ref(true)
     const infuraId = inject('infuraId') as string
     const appName = inject('appName') as string
+    const appUrl = inject('appUrl') as string
 
     // check metamask and walletconnect available
     onMounted(async () => {
@@ -70,7 +71,10 @@ export default defineComponent({
     }
 
     const connectMetamask = async () => {
-      if (metamaskDisabled.value) return
+      if (metamaskDisabled.value && appUrl) {
+        window.open(`https://metamask.app.link/dapp/${appUrl}`, '_blank')
+        return
+      } else if (metamaskDisabled.value) return
       // Prevent from closing the board while clicking disabled wallet
       close()
       openLoading()
@@ -99,6 +103,7 @@ export default defineComponent({
       metamaskDisabled,
       walletconnectDisabled,
       walletlinkDisabled,
+      appUrl,
       close,
       connectWallet,
 
@@ -117,7 +122,7 @@ export default defineComponent({
       <div
         @click="connectWallet('metamask')"
         class="wallet-item"
-        :class="metamaskDisabled ? 'wallet-disabled' : ''"
+        :class="metamaskDisabled && !appUrl ? 'wallet-disabled' : ''"
       >
         <div class="item">
           <MetaMaskIcon class="logo" />

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -6,6 +6,7 @@ import Modal from './components/Modal.vue'
 export type PluginOptions = {
   infuraId?: string
   appName?: string
+  appUrl?: string
 }
 
 export const VueDapp: Plugin = {
@@ -20,10 +21,16 @@ export const VueDapp: Plugin = {
         'For enabling WalletLink, you should provide the App Name in plugin options like "app.use(VueDapp, { appName: "<your-app-name>" })"',
       )
     }
+    if (!options?.appUrl) {
+      console.warn(
+        'For enabling a MetaMask fallback, you should provide the App Url in plugin options like "app.use(VueDapp, { appUrl: "<your-app-url>" })"',
+      )
+    }
     app.directive('click-outside', clickOutside)
     app.component('vdapp-board', Board)
     app.component('vdapp-modal', Modal)
     app.provide('infuraId', options?.infuraId)
     app.provide('appName', options?.appName)
+    app.provide('appUrl', options?.appUrl)
   },
 }


### PR DESCRIPTION
Add and optional appUrl parameter and functionality to deep link to MetaMask wallet on mobile devices, or open the app store if MetaMask app isn't installed on the device. This will also open the MetaMask website on desktop is the app isn't installed.

If the appUrl is not provide the button will be disabled the same as it is currently

fixed #26