### PR TITLE
Avoid uncaught error when user closes the WalletConnect QR modal.

### DIFF
--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -75,11 +75,7 @@ export function useWallet(options: useWalletOptions = { useEthers: true }) {
       }
     } catch (err: any) {
       await disconnect() // will also clearWallet()
-      if (err.message === 'Error: User closed modal') {
-        return console.log(err.message)
-      }
       wallet.error = err.message
-      throw new Error(err)
     }
 
     wallet.status = 'connected'

--- a/src/composables/useWallet.ts
+++ b/src/composables/useWallet.ts
@@ -75,6 +75,9 @@ export function useWallet(options: useWalletOptions = { useEthers: true }) {
       }
     } catch (err: any) {
       await disconnect() // will also clearWallet()
+      if (err.message === 'Error: User closed modal') {
+        return console.log(err.message)
+      }
       wallet.error = err.message
       throw new Error(err)
     }


### PR DESCRIPTION
Currently when you open the connect modal.

If you select WalletConnect and on the QR code screen, close the window. you will have an `uncaught` error in your application.
 
https://user-images.githubusercontent.com/2920357/182679322-848d9e94-8d93-49ea-8e2f-a443933cf4d3.mov
