### PR TITLE
fix: use computed <ref> signer to avoid errors

### DIFF
--- a/src/composables/useEthers.ts
+++ b/src/composables/useEthers.ts
@@ -81,7 +81,8 @@ async function activate(externalProvider: ExternalProvider) {
 
   const updateBalance = async (interval: number = 10000) => {
     setInterval(async () => {
-      const _balance = await _signer.getBalance()
+      if (!signer.value) return
+      const _balance = await signer?.value.getBalance()
       balance.value = _balance.toBigInt()
     }, interval)
   }


### PR DESCRIPTION
Hi @chnejohnson I believe this was a bug I've introduced myself.

https://user-images.githubusercontent.com/2920357/184504267-17318b40-e8bb-44eb-875c-f776126625b8.mov

When updating the balance on an interval it was using the `old` signer value. This now fixed.