### PR TITLE
fix: autoConnect not working in Firefox

### DIFF
--- a/src/connectors/metaMask.ts
+++ b/src/connectors/metaMask.ts
@@ -74,7 +74,7 @@ export class MetaMaskConnector extends Connector<
   static async checkConnection() {
     if (typeof window !== 'undefined' && !!window.ethereum) {
       const provider = window.ethereum as MetaMaskProvider
-      if (provider.selectedAddress) {
+      if ((await provider.request({ method: 'eth_accounts' })).length !== 0) {
         return true
       }
     }


### PR DESCRIPTION
Firefox won't auto connect on page refresh because `ethereum.selectedAddress` was null at the time of calling `checkConnection` method.
Property `ethereum.selectedAddress` is deprecated and was changed to using `eth_accounts` as described in [MetaMask documentation](https://docs.metamask.io/guide/ethereum-provider.html#ethereum-selectedaddress-deprecated).