### PR TITLE
chore: avoid throw error

### DIFF
--- a/src/composables/useEthers.ts
+++ b/src/composables/useEthers.ts
@@ -101,7 +101,7 @@ async function activate(externalProvider: ExternalProvider) {
         const _balance = await signer?.value.getBalance()
         balance.value = _balance.toBigInt()
       } catch (error: any) {
-        throw new Error('Failed to update balance')
+        console.warn('Failed to update balance')
       }
     }, interval)
   }


### PR DESCRIPTION
My UI is getting this `Uncaught (in promise) Error: Failed to update balance` witch happens when vue-dapp internally tries to update the balance on an interval.

That may can just be a console warn, to avoid the error ?

<img width="682" alt="Screenshot 2023-03-29 at 10 26 59" src="https://user-images.githubusercontent.com/2920357/228473646-850017be-a5bd-4795-9bce-d8929cb32b5a.png">
